### PR TITLE
front end validation

### DIFF
--- a/frontend/src/components/AccountPage.tsx
+++ b/frontend/src/components/AccountPage.tsx
@@ -9,6 +9,7 @@ import { UserContext, UserContextType } from "../contexts/UserContext";
 import useIsMobile from "../hooks/useIsMobile";
 import { Button } from "./Button";
 import { TextField } from "./TextField";
+import { validatePassword, validateUsername } from "../components/user/utils";
 
 const SettingsCard = styled.form`
   border-radius: 20px;
@@ -62,6 +63,11 @@ function AccountPage() {
   // ================ Event handlers ==================
   const handleChangeUsername = async (e: any) => {
     e.preventDefault();
+
+    const usernameIsValid = validateUsername(username);
+    setIsUsernameError(!usernameIsValid);
+    if(!usernameIsValid){return;}
+
     await apiCallUserChangeUsername(username, "")
       .then((response) => {
         if (response.status === 200) {
@@ -80,6 +86,11 @@ function AccountPage() {
 
   const handleChangePassword = async (e: any) => {
     e.preventDefault();
+
+    const passwordIsValid = validatePassword(password, password);
+    setIsPasswordError(!passwordIsValid);
+    if(!passwordIsValid){return;}
+    
     await apiCallUserChangePassword("", password)
       .then((response) => {
         if (response.status === 200) {

--- a/frontend/src/components/AccountPage.tsx
+++ b/frontend/src/components/AccountPage.tsx
@@ -7,6 +7,8 @@ import {
 } from "../api/UserServiceApi";
 import { UserContext, UserContextType } from "../contexts/UserContext";
 import useIsMobile from "../hooks/useIsMobile";
+import { Snackbar} from "@mui/material";
+import MuiAlert from "@mui/material/Alert";
 import { Button } from "./Button";
 import { TextField } from "./TextField";
 import { validatePassword, validateUsername } from "../components/user/utils";
@@ -50,8 +52,7 @@ function AccountPage() {
   // ================ State management ================
   // UI states
   const isMobile = useIsMobile();
-  const [isErrorSnackbarOpen, setIsErrorSnackbarOpen] =
-    useState<Boolean>(false);
+  const [isErrorSnackbarOpen, setIsErrorSnackbarOpen] = useState(false);
   const [errorSnackBarContent, setErrorSnackbarContent] = useState<String>("");
 
   // contexts
@@ -74,7 +75,8 @@ function AccountPage() {
           navigate("/");
         } else {
           const errorMessage: string =
-            "Something went wrong! Please try again later.";
+          response.data.message ??
+          "Something went wrong! Please try again later.";
           setErrorSnackbarContent(errorMessage);
         }
         setIsErrorSnackbarOpen(true);
@@ -140,6 +142,25 @@ function AccountPage() {
     <Button onClick={handleChangePassword}>Confirm New Password</Button>
   );
 
+  /**
+   * This renders the error snackbar.
+   */
+   const errorSnackbar = (
+    <Snackbar
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      open={isErrorSnackbarOpen}
+      autoHideDuration={5000}
+      onClose={() => setIsErrorSnackbarOpen(false)}
+      role="alert"
+    >
+      <MuiAlert elevation={6} variant="filled" severity="error">
+        {errorSnackBarContent}
+      </MuiAlert>
+    </Snackbar>
+  );
+
+
+
   // ====== Render ======
   return (
     <SettingsCard>
@@ -150,6 +171,7 @@ function AccountPage() {
         {changePassword_TextField}
         <ButtonContainer>{changePassword_button}</ButtonContainer>
       </form>
+      {errorSnackbar}
     </SettingsCard>
   );
 }

--- a/user-service/src/constants.ts
+++ b/user-service/src/constants.ts
@@ -27,6 +27,7 @@ export const ENV_IS_PROD = process.env.ENV == 'PROD'
  */
 export const CORS_OPTIONS: cors.CorsOptions = {
   credentials: true,
+  // origin: '*'
   origin: 'http://localhost:3000' // TODO: currently we allow all origins
 }
 

--- a/user-service/src/controller/services/response-services.ts
+++ b/user-service/src/controller/services/response-services.ts
@@ -31,7 +31,7 @@ export function createInternalServerErrorResponse(
 ) {
   return response
     .status(statusCode ?? 500)
-    .json({ message: message ?? "Internal server error." });
+    .json({ data:{ message: message ?? "Internal server error." }});
 }
 
 export function createOkResponse(response: Response, data?: unknown) {
@@ -39,5 +39,5 @@ export function createOkResponse(response: Response, data?: unknown) {
 }
 
 export function createBadRequestResponse(response: Response, message?: string) {
-  return response.status(400).json({ message: message ?? "Bad request." });
+  return response.status(400).json({ data:{ message: message ?? "Bad request." }});
 }

--- a/user-service/src/exceptions.ts
+++ b/user-service/src/exceptions.ts
@@ -21,6 +21,32 @@ export class UserDetailValidationException extends UserServiceException {
 }
 
 /**
+ * Exception thrown when creating/renaming an account clashes with an existing account
+ */
+ export class UsernameClashException extends UserServiceException {
+  constructor(message: string) {
+    super(message,409);
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, DbWriteException.prototype);
+  }
+}
+
+/**
+ * Exception thrown when deleting an account that does not exist
+ */
+ export class UserNotFoundException extends UserServiceException {
+  constructor(message: string) {
+    super(message,404);
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, DbWriteException.prototype);
+  }
+}
+
+
+
+/**
  * Exception thrown when there is an error writing to the database.
  */
 export class DbWriteException extends UserServiceException {

--- a/user-service/tests/test-api.ts
+++ b/user-service/tests/test-api.ts
@@ -46,7 +46,7 @@ describe("signup", () => {
     const res = await agent
       .post("/signup")
       .send({ username: "user1", password: "testpw" });
-    expect(res.statusCode).toEqual(500);
+    expect(res.statusCode).toEqual(409);
   });
 
   // empty username


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Overview
#78 

Add front end validation for username and password

### Main changes and their rationale(s)

* followed style of text field validation error used in signup/login 

Some considerations were y

imported the same checker from login, so we can set stricter rules and standardize

### Things to take note of

* user-service response was not standardized, so front end wasn't picking it up
* used existing snackbar for error message
* tldr snackbar for back end errors, text box for front end validation error

### Testing

e.g. Simply run:
```
cypress <some file>.ts
```

![image](https://user-images.githubusercontent.com/42330243/198320072-1b18337c-cb21-4f20-af1f-224507cf449f.png)

