### PR TITLE
Style History Page

### DIFF
--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -1,12 +1,74 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import styled from "styled-components";
 import {
   apiGetRoomHistory,
   convertRoomApiResponseToRoom,
   RoomApiResponseData,
 } from "../api/CollaborationServiceApi";
+import { UserContext, UserContextType } from "../contexts/UserContext";
 import { Room } from "../interfaces/collaboration/Room";
 
+const HistoryComponent = styled.div`
+  h1 {
+    color: rgb(255, 179, 117);
+    margin: 0 0 2rem 0;
+    text-align: center;
+    text-shadow: 5px 2px 20px rgba(255, 90, 8, 0.8);
+  }
+`;
+
+const Stats = styled.div`
+  display: grid;
+  grid-column-gap: 3rem;
+  grid-template-columns: 1fr 1fr 1fr;
+  margin: 3rem 0;
+`;
+
+const Counter = styled.div`
+  border-radius: 20px;
+  box-shadow: 5px 5px 15px 5px rgba(0, 0, 0, 0.4),
+    -5px -5px 15px 5px rgba(63, 63, 74, 1);
+  padding: 2rem;
+  text-align: center;
+
+  div:first-of-type {
+    color: rgb(255, 179, 117);
+    font-size: 3rem;
+    font-weight: bold;
+    margin: 0 0 2rem 0;
+    text-shadow: 5px 2px 20px rgba(255, 90, 8, 0.8);
+  }
+
+  div:last-of-type {
+    font-weight: bold;
+  }
+`;
+
+const RoomList = styled.ul`
+  border-radius: 20px;
+  box-shadow: 5px 5px 15px 5px rgba(0, 0, 0, 0.4),
+    -5px -5px 15px 5px rgba(63, 63, 74, 1);
+  list-style-type: none;
+  padding: 2rem;
+
+  li {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    margin: 1rem 0 0 0;
+  }
+
+  li:first-of-type {
+    color: rgb(255, 179, 117);
+    font-weight: bold;
+    margin: 0;
+    text-shadow: 5px 2px 20px rgba(255, 90, 8, 0.8);
+  }
+`;
+
+const difficultyMap = ["Easy", "Medium", "Hard"];
+
 export function HistoryPage() {
+  const { user } = useContext(UserContext) as UserContextType;
   // ================ state management ================
   const [rooms, setRooms] = useState<Room[]>([]);
 
@@ -42,18 +104,29 @@ export function HistoryPage() {
    * A given room card.
    */
   const roomComponentListItem = (room: Room) => {
-    return <>Some room</>;
+    return <li>
+      <div>{ room.createdAt }</div>
+      <div>{ room.question.title }</div>
+      <div>{ difficultyMap[room.question.difficulty] }</div>
+      <div>{ room.roomId }</div>
+    </li>;
   };
 
   /**
    * List of rooms
    */
   const roomComponentList = (
-    <li>
+    <RoomList>
+      <li>
+        <div>Created At</div>
+        <div>Question</div>
+        <div>Difficulty</div>
+        <div>Room Id</div>
+      </li>
       {rooms?.map((room: Room) => {
         return roomComponentListItem(room);
       })}
-    </li>
+    </RoomList>
   );
 
   /**
@@ -62,9 +135,17 @@ export function HistoryPage() {
   const noRooms = <div>You've not had any session </div>;
 
   return (
-    <>
+    <HistoryComponent>
       <h1>Match History</h1>
+      <Stats>
+        {difficultyMap.map((difficulty, key) => {
+          return <Counter>
+            <div>{rooms.filter(room => room.question.difficulty == key).length}</div>
+            <div>{ difficulty }</div>
+          </Counter>
+        })}
+      </Stats>
       {rooms.length > 0 ? roomComponentList : noRooms}
-    </>
+    </HistoryComponent>
   );
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Overview
Prettify match history page on frontend
<img width="1440" alt="Screen Shot 2022-10-28 at 3 48 31 PM" src="https://user-images.githubusercontent.com/15025605/198533586-d2ac2477-d3b8-4b23-8484-269c4ab5be9b.png">



### Things to take note of

* Dates seem to have inconsistent formats, resulting in weird-looking string

### Testing
Run frontend
