### PR TITLE
Collaboration room refresh disconnect bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       - MODE=DEV
       - FRONTEND_URI=http://localhost:3000
-      - COLLABORATION_SERVICE_URI=http://collaboration-service:8003
+      - COLLABORATION_SERVICE_URI=http://localhost:8003
       - RABBITMQ_URI=amqp://rabbitmq:5672
       - PORT=8001
 

--- a/frontend/src/components/collaboration/RealTimeCollaborativeEditor.tsx
+++ b/frontend/src/components/collaboration/RealTimeCollaborativeEditor.tsx
@@ -21,7 +21,7 @@ export default function RealTimeCollaborativeEditor(props: {
   username: string;
   userId: string;
   language: string;
-  initialCode: string;
+  initialCode?: string;
   codeCallback: (code: string) => void;
 }) {
   // =========== props =========================
@@ -57,7 +57,9 @@ export default function RealTimeCollaborativeEditor(props: {
       // 1. create yjs document and get text from codemirror editor
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("codemirror");
-      yText.insert(0, initialCode);
+      if (!!initialCode) {
+        yText.insert(0, initialCode);
+      }
 
       // TODO: as import signalling servers for y-webrtc
       const signallingServers = Y_JS_SIGNALLING_SERVERS;
@@ -67,7 +69,7 @@ export default function RealTimeCollaborativeEditor(props: {
       //@ts-ignore
       const provider = new WebrtcProvider(roomId, yDoc, {
         signaling: signallingServers,
-        maxConns: 2, // only support 2 for now
+        maxConns: 10, // only support 2 for now
       });
 
       // 3. include a undo manager
@@ -77,7 +79,7 @@ export default function RealTimeCollaborativeEditor(props: {
       // TODO: fix bug here with name
       const color = RandomColor();
       const awareness = provider.awareness;
-      awareness.setLocalState({
+      awareness.setLocalStateField("user", {
         name: username,
         color: color,
       });

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -149,6 +149,9 @@ const UserContextProvider = (props: { children: JSX.Element }) => {
    * Clears the websocket connection.
    */
   const clearWebSocket = async () => {
+    if (webSocket) {
+      webSocket.close();
+    }
     setWebSocket(undefined);
   };
 

--- a/user-service/src/db/db.ts
+++ b/user-service/src/db/db.ts
@@ -13,7 +13,7 @@ let mock_db: MongoMemoryServer | null = null;
 /**
  * This function is called to populate the dev db with data from the local json file.
  */
-const populateDevDb = () => {
+const populateDevDb = async () => {
   const db = mongoose.connection;
 
   // 1. if dev, populate
@@ -26,14 +26,16 @@ const populateDevDb = () => {
     try {
       // clear db
       console.log("Clearing existing tables");
-      tables.forEach((table) => {
-        db.collection(table)
+      tables.forEach(async (table) => {
+        await db
+          .collection(table)
           .drop()
           .catch((error) => {
             console.error(
-              "Tried to drop table " + table + " but it doesn't exist."
+              "\n**Tried to drop table " + table + " but it doesn't exist."
             );
             console.error(error);
+            console.error("\n**");
           });
       });
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Overview

Closes #78

Bug was due to race conditions between setting state from the backend server and the live socket connection between editors. Specifically, when a user refreshed, we would get the state from the backend, set that in the editor, then open the connection to the other user's editor. 

This would cause an error and close the connection. 

This has since been fixed by having frontend state be set only if there is 1 user in the room (i.e. no such conflicts occur). 

