### PR TITLE
make QS diff endpoint return random question

### DIFF
--- a/question-service/src/controller/services/question-services.ts
+++ b/question-service/src/controller/services/question-services.ts
@@ -6,8 +6,16 @@ import QuestionModel from "../../models/question-model";
  */
 const get_question_by_difficulty = async (difficulty: QuestionDifficulty) => {
   // using mongoose wrapper, query
-  const questionModel = await QuestionModel.findOne() // find one picks randomly. see https://stackoverflow.com/questions/39277670/how-to-find-random-record-in-mongoose
-    .where("difficulty")
+  
+
+  const count = await QuestionModel.count({"difficulty":difficulty});
+  const  random = Math.floor(Math.random() * count);
+  
+  
+  const questionModel = await QuestionModel
+  .findOne() // find one picks randomly. see https://stackoverflow.com/questions/39277670/how-to-find-random-record-in-mongoose
+  .skip(random)
+  .where("difficulty")
     .equals(difficulty)
     .catch((err) => {
       console.log(err);

--- a/question-service/src/dev-data.json
+++ b/question-service/src/dev-data.json
@@ -14,14 +14,38 @@
       "difficulty": 0,
       "topic": 0
     },
+
+
     {
-      "qid": "3",
-      "title": "question 3",
-      "description": "question 3 long desc",
+      "qid": "10",
+      "title": "Find and Replace Pattern",
+      "description": "Given a list of strings `words` and a string `pattern`, return a list of `words[i]` that match `pattern`. You may return the answer in any order. A word matches the pattern if there exists a permutation of letters `p` so that after replacing every letter `x` in the pattern with `p(x)`, we get the desired word. Recall that a permutation of letters is a bijection from letters to letters: every letter maps to another letter, and no two letters map to the same letter.",
+      "difficulty": 1,
+      "topic": 0
+    },
+    {
+      "qid": "11",
+      "title": "question 11",
+      "description": "question 11 long desc",
+      "difficulty": 1,
+      "topic": 0
+    },
+
+
+    {
+      "qid": "21",
+      "title": "question 21",
+      "description": "question 21 long desc",
+      "difficulty": 1,
+      "topic": 0
+    },
+    {
+      "qid": "22",
+      "title": "question 22",
+      "description": "question 22 long desc",
       "difficulty": 1,
       "topic": 0
     }
-
 
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Overview

Fix question service get by difficulty endpoint to return a a randomly generated question

### Main changes and their rationale(s)

* added random skip so that its not always the first valid value returned
*  added template question on each difficulty for testing that returned question can change

### Testing
Use postman to post to the /difficulty endpoint multiple times, different questions should appear
