### PR TITLE
Tweak docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       - MODE=DEV
       - FRONTEND_URI=http://localhost:3000
-      - COLLABORATION_SERVICE_URI=http://localhost:8003
+      - COLLABORATION_SERVICE_URI=http://collaboration-service:8003
       - RABBITMQ_URI=amqp://rabbitmq:5672
       - PORT=8001
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Overview

Tweak collar service uri env variable specified in docker compose. This fixes the matching service bug which appears when running docker

### Testing

Run docker compose and create a match
